### PR TITLE
feat: add lint-manifests action

### DIFF
--- a/lint-manifests/action.yml
+++ b/lint-manifests/action.yml
@@ -1,0 +1,45 @@
+name: sre-actions/lint-manifests
+description: Lint kubernetes manifests
+author: sys-gdp
+inputs:
+  env:
+    description: Environment to lint
+    required: true
+  product:
+    description: Product to lint
+    required: false
+    default: ''
+  k8s-version:
+    description: Kubernetes version
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: asdf-vm/actions/install@v2.1.0
+      with:
+        tool_versions: |
+          kustomize 4.5.7
+          helm 3.10.1
+          kube-score 1.16.1
+          kubeconform 0.6.1
+          pluto 5.16.1
+
+    - run: ${{ github.action_path }}/lint.sh
+      shell: bash
+      env:
+        ENV: ${{ inputs.env }}
+        PRODUCT: ${{ inputs.product }}
+        K8S_VERSION: ${{ inputs.k8s-version }}
+
+    - uses: actions/github-script@v6.4.1
+      with:
+        script: |
+          const { promises: fs } = require('fs');
+          await github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: await fs.readFile('output.md', 'utf8'),
+          });
+      if: failure() && github.event_name == 'pull_request'

--- a/lint-manifests/lint.sh
+++ b/lint-manifests/lint.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+env="$ENV"
+product="$PRODUCT"
+k8s_version="$K8S_VERSION"
+output_file=output.md
+
+type kustomize
+type kube-score
+type kubeconform
+
+if [ -z "$product" ]; then
+  kustomize_path="overlays/$env"
+else
+  kustomize_path="$product/overlays/$env"
+fi
+
+echo "kustomize path: $kustomize_path"
+echo "working directory: $(pwd)"
+
+manifest=$(kustomize build "$kustomize_path" 2>&1)
+rc=$?
+if [ $rc -ne 0 ]; then
+  tee $output_file << EOS
+### kustomize build [$kustomize_path]
+\`\`\`
+$manifest
+\`\`\`
+EOS
+  exit 1
+fi
+
+echo "build manifests successfully."
+
+kubeconform=$(echo "$manifest" | kubeconform \
+  -ignore-missing-schemas \
+  -strict -output tap \
+  -kubernetes-version "$k8s_version" 2>&1)
+rc1=$?
+
+kube_score=$(echo "$manifest" | kube-score score -o ci - \
+  --enable-optional-test container-security-context-privileged \
+  --ignore-test container-security-context \
+  --ignore-test pod-probes 2>&1)
+rc2=$?
+
+tee $output_file << EOS
+### kubeconform [$kustomize_path]
+
+<details><summary>show outputs</summary>
+
+\`\`\`
+$kubeconform
+\`\`\`
+
+</details>
+
+### kube-score [$kustomize_path]
+
+<details><summary>show outputs</summary>
+
+\`\`\`
+$kube_score
+\`\`\`
+
+</details>
+EOS
+
+if [[ $rc1 -ne 0 || $rc2 -ne 0 ]]; then
+  exit 1
+fi
+
+echo "kubeconform and kube-score passed."


### PR DESCRIPTION
- プロダクトの k8s manifest に linter を適用する共通の action を作成する
- reusable workflow でも良かったが composite action で定義している
  - 呼び出すときに記述量が少ない以外の理由は特にない