### PR TITLE
Add reusable workflows

### DIFF
--- a/.github/workflows/reusable-ecs-task-registration.yaml
+++ b/.github/workflows/reusable-ecs-task-registration.yaml
@@ -1,0 +1,70 @@
+name: Reusable workflow for ECS task definition registration
+on:
+  workflow_call:
+    inputs:
+      env:
+        required: true
+        type: string
+      role-to-assume:
+        required: true
+        type: string
+      task-definition-template-path:
+        required: false
+        type: string
+        default: task_definition/db_dump_backup/template.json.j2
+      task-variables:
+        required: false
+        type: string
+        default: ''
+      slack-channel:
+        required: true
+        type: string
+      ecs-cluster:
+        required: true
+        type: string
+    secrets:
+      slack-oauth-token:
+        required: true
+
+env:
+  TASK_DEFINITION_OUTPUT_FILE_NAME: task-definition.json
+
+jobs:
+  deploy:
+    name: Register task definition
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v3.5.2
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v2.0.0
+        with:
+          role-to-assume: ${{ inputs.role-to-assume }}
+          role-session-name: github-actions
+          aws-region: ap-northeast-1
+
+      - name: Setup task definition
+        uses: cuchi/jinja2-action@v1.2.1
+        with:
+          template: ${{ inputs.task-definition-template-path }}
+          output_file: ${{ env.TASK_DEFINITION_OUTPUT_FILE_NAME }}
+          variables: ${{ inputs.task-variables }}
+
+      # 登録するtask definitionの状態をログ出力しておく
+      - name: Show the new task definition
+        run: cat ./${{ env.TASK_DEFINITION_OUTPUT_FILE_NAME }}
+
+      - name: Register new task definition family
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1.4.11
+        with:
+          task-definition: ${{ env.TASK_DEFINITION_OUTPUT_FILE_NAME }}
+          cluster: ${{ inputs.ecs-cluster }}
+
+      - name: Notify job status
+        uses: globis-org/sre-actions/deploybot@v1
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.slack-oauth-token }}
+          channel: ${{ inputs.slack-channel }}
+        if: ${{ failure() }}

--- a/.github/workflows/reusable-sls-deployment.yaml
+++ b/.github/workflows/reusable-sls-deployment.yaml
@@ -1,0 +1,49 @@
+name: Reusable workflow for sls deployment
+on:
+  workflow_call:
+    inputs:
+      role-to-assume:
+        required: true
+        type: string
+      workspace:
+        required: true
+        type: string
+      env:
+        required: true
+        type: string
+      python-version:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  sls-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - uses: actions/setup-node@v3.6.0
+        with:
+          node-version: "18"
+          cache: yarn
+          cache-dependency-path: ./serverless/yarn.lock
+
+      - uses: actions/setup-python@v4.6.0
+        if: inputs.python-version != ''
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.0.0
+        with:
+          aws-region: ap-northeast-1
+          role-to-assume: ${{ inputs.role-to-assume }}
+
+      - name: Install dependencies
+        working-directory: ./serverless
+        run: yarn install --frozen-lockfile
+
+      - name: Deploy serverless
+        working-directory: ./serverless
+        run: |
+          yarn workspace ${{ inputs.workspace }} run deploy:${{ inputs.env }}
+          yarn workspace ${{ inputs.workspace }} run info:${{ inputs.env }}


### PR DESCRIPTION
* globis-org/core-infra#1579
    * https://github.com/globis-org/aws-products-infra/pull/3719 で作成した `sls deploy` のreusable workflowをこちらへ移動
        * `sls deploy` はaws-products-infraからしかしないだろう、と思ったらecs-job-infraにもあったため、こちらで共有したほうがいいと判断。
    * ECSタスク定義を登録するreusable workflowも追加
        * こちらこそecs-job-infraでしか使わなさそうではあるが、一応
        * なるべく汎用的に使えるようにしている。若干差分はあるものの、ecs-job-infraで一度別ブランチから検証実行済み。 https://github.com/globis-org/ecs-job-infra/actions/runs/4850067198