### PR TITLE
refactor: lint の結果を job summary で通知するように変更

### DIFF
--- a/lint-manifests/action.yml
+++ b/lint-manifests/action.yml
@@ -36,10 +36,6 @@ runs:
       with:
         script: |
           const { promises: fs } = require('fs');
-          await github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: await fs.readFile('output.md', 'utf8'),
-          });
-      if: failure() && github.event_name == 'pull_request'
+          const output = await fs.readFile('output.md', 'utf8');
+          await core.summary.addRaw(output).write();
+      if: always()

--- a/lint-manifests/lint.sh
+++ b/lint-manifests/lint.sh
@@ -5,6 +5,14 @@ product="$PRODUCT"
 version="$K8S_VERSION"
 output_file=output.md
 
+function get_emoji() {
+  if [ $1 -eq 0 ]; then
+    echo ✅
+  else
+    echo 💥
+  fi
+}
+
 format="v[0-9]+.[0-9]+.[0-9]+"
 
 if [[ ! $version =~ $format ]]; then
@@ -56,7 +64,7 @@ kube_score=$(echo "$manifest" | kube-score score -o ci - \
 rc2=$?
 
 tee $output_file << EOS
-### kubeconform [$kustomize_path]
+### $(get_emoji $rc1) kubeconform [$kustomize_path]
 
 <details><summary>show outputs</summary>
 
@@ -66,7 +74,7 @@ $kubeconform
 
 </details>
 
-### kube-score [$kustomize_path]
+### $(get_emoji $rc2) kube-score [$kustomize_path]
 
 <details><summary>show outputs</summary>
 


### PR DESCRIPTION
- `lint-manifests` が失敗した時に PR にコメントする形から、必ず Job Summary に追加する形に変更する
- ついでに結果を絵文字でわかりやすくする