### PR TITLE
feat: manifest-analyzerの解析結果をartifactに保存する機能を追加

### DIFF
--- a/manifest-analyzer/action.yml
+++ b/manifest-analyzer/action.yml
@@ -11,6 +11,14 @@ inputs:
   k8s-version:
     description: Kubernetes version
     required: true
+  artifact-name:
+    description: Name of the artifact to upload
+    required: false
+    default: manifest-analysis-results
+  artifact-retention-days:
+    description: Number of days to retain the artifact
+    required: false
+    default: '7'
 
 runs:
   using: composite
@@ -53,4 +61,13 @@ runs:
           const dyff = await fs.readFile('${{ steps.dyff.outputs.file }}', 'utf8');
           const lint = await fs.readFile('${{ steps.lint.outputs.file }}', 'utf8');
           await core.summary.addRaw(dyff).addEOL().addRaw(lint).write();
+      if: always()
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.6.2
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          ${{ steps.dyff.outputs.file }}
+          ${{ steps.lint.outputs.file }}
+        retention-days: ${{ inputs.artifact-retention-days }}
       if: always()

--- a/manifest-analyzer/action.yml
+++ b/manifest-analyzer/action.yml
@@ -12,9 +12,9 @@ inputs:
     description: Kubernetes version
     required: true
   artifact-name:
-    description: Name of the artifact to upload
+    description: Name of the artifact to upload (if specified, results will be uploaded)
     required: false
-    default: manifest-analysis-results
+    default: ''
   artifact-retention-days:
     description: Number of days to retain the artifact
     required: false
@@ -70,4 +70,4 @@ runs:
           ${{ steps.dyff.outputs.file }}
           ${{ steps.lint.outputs.file }}
         retention-days: ${{ inputs.artifact-retention-days }}
-      if: always()
+      if: always() && inputs.artifact-name != ''


### PR DESCRIPTION
- dyff.mdとlint.mdをartifactとして保存
- artifact名と保存期間をパラメータ化
- デフォルト保存期間を7日に設定（PR用途に最適化）
- actions/upload-artifactをv4.6.2に更新

🤖 Generated with [Claude Code](https://claude.ai/code)