### PR TITLE
feat: manifest-analyzerをasdfからmiseに移行し外部設定ファイルを使用

### DIFF
--- a/manifest-analyzer/.tool-versions
+++ b/manifest-analyzer/.tool-versions
@@ -1,5 +1,0 @@
-kustomize 5.2.1
-kube-score 1.18.0
-kubeconform 0.6.7
-pluto 5.20.2
-dyff 1.9.0

--- a/manifest-analyzer/.tool-versions
+++ b/manifest-analyzer/.tool-versions
@@ -1,0 +1,5 @@
+kustomize 5.2.1
+kube-score 1.18.0
+kubeconform 0.6.7
+pluto 5.20.2
+dyff 1.9.0

--- a/manifest-analyzer/action.yaml
+++ b/manifest-analyzer/action.yaml
@@ -23,9 +23,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mise-action@v2
-      with:
-        working_directory: ${{ github.action_path }}
+    - uses: jdx/mise-action@v2.3.1
+      env:
+        MISE_GLOBAL_CONFIG_FILE: ${{ github.action_path }}/mise.toml
 
     - id: kustomize
       run: ${{ github.action_path }}/kustomize.sh
@@ -33,6 +33,7 @@ runs:
       env:
         BASE_DIR: ${{ inputs.base-dir }}
         HEAD_DIR: ${{ inputs.head-dir }}
+        MISE_GLOBAL_CONFIG_FILE: ${{ github.action_path }}/mise.toml
 
     - id: dyff
       run: ${{ github.action_path }}/dyff.sh
@@ -40,6 +41,7 @@ runs:
       env:
         BASE_DIR: ${{ inputs.base-dir }}
         HEAD_DIR: ${{ inputs.head-dir }}
+        MISE_GLOBAL_CONFIG_FILE: ${{ github.action_path }}/mise.toml
 
     - id: lint
       run: ${{ github.action_path }}/lint.sh
@@ -48,6 +50,7 @@ runs:
         BASE_DIR: ${{ inputs.base-dir }}
         HEAD_DIR: ${{ inputs.head-dir }}
         K8S_VERSION: ${{ inputs.k8s-version }}
+        MISE_GLOBAL_CONFIG_FILE: ${{ github.action_path }}/mise.toml
 
     - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:

--- a/manifest-analyzer/action.yaml
+++ b/manifest-analyzer/action.yaml
@@ -23,9 +23,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302 # v4.0.0
+    - uses: jdx/mise-action@v2
       with:
-        before_install: pwd; ls -la; cd ${{ github.action_path }}
+        working_directory: ${{ github.action_path }}
 
     - id: kustomize
       run: ${{ github.action_path }}/kustomize.sh

--- a/manifest-analyzer/action.yaml
+++ b/manifest-analyzer/action.yaml
@@ -23,14 +23,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
-      with:
-        tool_versions: |
-          kustomize 5.2.1 # Argo CD v2.11.3
-          kube-score 1.18.0
-          kubeconform 0.6.7
-          pluto 5.20.2
-          dyff 1.9.0
+    - uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302 # v4.0.0
+      working-directory: ${{ github.action_path }}
 
     - id: kustomize
       run: ${{ github.action_path }}/kustomize.sh

--- a/manifest-analyzer/action.yaml
+++ b/manifest-analyzer/action.yaml
@@ -24,7 +24,8 @@ runs:
   using: composite
   steps:
     - uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302 # v4.0.0
-      working-directory: ${{ github.action_path }}
+      with:
+        before_install: pwd; ls -la; cd ${{ github.action_path }}
 
     - id: kustomize
       run: ${{ github.action_path }}/kustomize.sh

--- a/manifest-analyzer/mise.toml
+++ b/manifest-analyzer/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+kustomize = "5.2.1" # Argo CD v2.11.3
+kube-score = "1.18.0"
+kubeconform = "0.6.7"
+pluto = "5.20.2"
+dyff = "1.9.0"


### PR DESCRIPTION
## Summary / 概要

manifest-analyzerアクションをasdf-vm/actionsからmise-actionに移行し、外部のツールバージョン設定ファイルを使用するように変更。

## Changes / 変更内容

- asdf-vm/actions@v3.0.2をjdx/mise-action@v2.3.1に置き換え
  - mise-actionの方が設定ファイルを分離したときの対応が楽だった。
- ハードコードされていたtool_versionsを外部のmise.toml設定ファイルに移行
- MISE_GLOBAL_CONFIG_FILE環境変数を使用したツールバージョン管理

**ツールバージョン（変更なし）:**
- kustomize: 5.2.1 (Argo CD v2.11.3)
- kube-score: 1.18.0
- kubeconform: 0.6.7
- pluto: 5.20.2
- dyff: 1.9.0

## Type of Change / 変更タイプ

- [x] New feature / 新機能
- [ ] Bug fix / バグ修正
- [ ] Breaking change / 破壊的変更
- [ ] Documentation update / ドキュメント更新

🤖 Generated with [Claude Code](https://claude.ai/code)