### PR TITLE
feat: tool_versionsを.tool-versionsファイルに分離し、asdf-vm/actionsをv4に更新

### DIFF
--- a/manifest-analyzer/.tool-versions
+++ b/manifest-analyzer/.tool-versions
@@ -1,0 +1,5 @@
+kustomize 5.2.1 # Argo CD v2.11.3
+kube-score 1.18.0
+kubeconform 0.6.7
+pluto 5.20.2
+dyff 1.9.0

--- a/manifest-analyzer/action.yaml
+++ b/manifest-analyzer/action.yaml
@@ -23,14 +23,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
-      with:
-        tool_versions: |
-          kustomize 5.2.1 # Argo CD v2.11.3
-          kube-score 1.18.0
-          kubeconform 0.6.7
-          pluto 5.20.2
-          dyff 1.9.0
+    - uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302 # v4.0.0
+      env:
+        ASDF_TOOL_VERSIONS_FILENAME: ${{ github.action_path }}/.tool-versions
 
     - id: kustomize
       run: ${{ github.action_path }}/kustomize.sh
@@ -38,6 +33,7 @@ runs:
       env:
         BASE_DIR: ${{ inputs.base-dir }}
         HEAD_DIR: ${{ inputs.head-dir }}
+        ASDF_TOOL_VERSIONS_FILENAME: ${{ github.action_path }}/.tool-versions
 
     - id: dyff
       run: ${{ github.action_path }}/dyff.sh
@@ -45,6 +41,7 @@ runs:
       env:
         BASE_DIR: ${{ inputs.base-dir }}
         HEAD_DIR: ${{ inputs.head-dir }}
+        ASDF_TOOL_VERSIONS_FILENAME: ${{ github.action_path }}/.tool-versions
 
     - id: lint
       run: ${{ github.action_path }}/lint.sh
@@ -53,6 +50,7 @@ runs:
         BASE_DIR: ${{ inputs.base-dir }}
         HEAD_DIR: ${{ inputs.head-dir }}
         K8S_VERSION: ${{ inputs.k8s-version }}
+        ASDF_TOOL_VERSIONS_FILENAME: ${{ github.action_path }}/.tool-versions
 
     - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:


### PR DESCRIPTION
## Summary / 概要

manifest-analyzerアクションでハードコードされていたtool_versionsを外部の.tool-versionsファイルに分離し、asdf-vm/actionsをv4に更新しました。

## Changes / 変更内容

- ハードコードされていたtool_versionsを.tool-versionsファイルに移行
- ASDF_TOOL_VERSIONS_FILENAME環境変数を使用して外部ファイルを参照
- asdf-vm/actions@v3.0.2からv4.0.0に更新
- 全てのステップでASDF_TOOL_VERSIONS_FILENAME環境変数を設定

**ツールバージョン（変更なし）:**
- kustomize: 5.2.1 (Argo CD v2.11.3)
- kube-score: 1.18.0
- kubeconform: 0.6.7
- pluto: 5.20.2
- dyff: 1.9.0

## Type of Change / 変更タイプ

- [x] New feature / 新機能
- [ ] Bug fix / バグ修正
- [ ] Breaking change / 破壊的変更
- [ ] Documentation update / ドキュメント更新

🤖 Generated with [Claude Code](https://claude.ai/code)