### PR TITLE
chore: engines.node の Renovate 自動更新を無効化

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.js",
   "engines": {
-    "node": "v24.13.0"
+    "node": ">=24"
   },
   "packageManager": "pnpm@10.27.0",
   "scripts": {

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,12 @@
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "npm dependencies (non-major)"
+    },
+    {
+      "description": "Disable updates for engines.node (managed manually based on GitHub Actions runtime support)",
+      "matchDepTypes": ["engines"],
+      "matchDepNames": ["node"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary / 概要

engines.node を GitHub Actions ランタイムのサポート状況に合わせて手動管理に変更

## Changes / 変更内容

- Renovate による engines.node の自動更新を無効化
- engines.node を固定バージョンから範囲指定 (`>=24`) に変更
- engine-strict=true を追加し、Node.js メジャーバージョンを強制

## Type of Change / 変更タイプ

- [x] Documentation update / ドキュメント更新