### PR TITLE
chore: 依存パッケージの一括更新と codeowners-validator テスト追加

### DIFF
--- a/aws-ssm-parameters/jest.config.js
+++ b/aws-ssm-parameters/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  transform: {
+    '^.+\\.tsx?$': '@swc/jest',
+  },
+  testEnvironment: 'node',
+}

--- a/aws-ssm-parameters/package.json
+++ b/aws-ssm-parameters/package.json
@@ -10,9 +10,9 @@
     "all": "pnpm type-check && pnpm package"
   },
   "dependencies": {
-    "@actions/core": "2.0.3",
+    "@actions/core": "3.0.1",
     "@aws-sdk/client-ssm": "3.1078.0",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/codeowners-validator/__tests__/parse.test.ts
+++ b/codeowners-validator/__tests__/parse.test.ts
@@ -1,0 +1,123 @@
+import {
+  replaceCodeOwnersPatternToGlobs,
+  parseCodeOwners,
+  getFileOwners,
+  listUniqueOwners,
+  type CodeOwnersRule,
+} from '../src/parse'
+
+describe('replaceCodeOwnersPatternToGlobs', () => {
+  test('wildcard patterns', () => {
+    expect(replaceCodeOwnersPatternToGlobs('*')).toEqual(['**'])
+    expect(replaceCodeOwnersPatternToGlobs('**')).toEqual(['**'])
+  })
+
+  test('leading slash matches root only', () => {
+    expect(replaceCodeOwnersPatternToGlobs('/src')).toEqual(['src', 'src/**'])
+  })
+
+  test('trailing slash matches as directory', () => {
+    expect(replaceCodeOwnersPatternToGlobs('/docs/')).toEqual(['docs/**'])
+    expect(replaceCodeOwnersPatternToGlobs('build/')).toEqual(['**/build/**'])
+  })
+
+  test('pattern without slash matches anywhere', () => {
+    expect(replaceCodeOwnersPatternToGlobs('*.ts')).toEqual(['**/*.ts'])
+  })
+
+  test('pattern with middle slash matches relative to root', () => {
+    expect(replaceCodeOwnersPatternToGlobs('src/utils')).toEqual(['src/utils', 'src/utils/**'])
+  })
+
+  test('pattern with extension treated as file', () => {
+    expect(replaceCodeOwnersPatternToGlobs('/src/main.ts')).toEqual(['src/main.ts'])
+  })
+
+  test('trailing wildcard treated as file pattern', () => {
+    expect(replaceCodeOwnersPatternToGlobs('/src/*')).toEqual(['src/*'])
+    expect(replaceCodeOwnersPatternToGlobs('/src/**')).toEqual(['src/**'])
+  })
+
+  test('dotfile without extension matches as file or directory', () => {
+    expect(replaceCodeOwnersPatternToGlobs('.github')).toEqual(['**/.github', '**/.github/**'])
+  })
+})
+
+describe('parseCodeOwners', () => {
+  test('parses user owners', () => {
+    const result = parseCodeOwners('* @alice @bob')
+    expect(result).toEqual([
+      {
+        glob: '**',
+        owners: [
+          { kind: 'user', name: 'alice' },
+          { kind: 'user', name: 'bob' },
+        ],
+      },
+    ])
+  })
+
+  test('parses team owners', () => {
+    const result = parseCodeOwners('/src/ @org/team-a')
+    expect(result).toEqual([
+      {
+        glob: 'src/**',
+        owners: [{ kind: 'team', name: 'org/team-a', org: 'org', team: 'team-a' }],
+      },
+    ])
+  })
+
+  test('skips blank lines', () => {
+    const result = parseCodeOwners('* @alice\n\n/docs/ @bob')
+    expect(result).toHaveLength(2)
+  })
+
+  test('expands patterns to multiple globs', () => {
+    const result = parseCodeOwners('/src @alice')
+    expect(result).toEqual([
+      { glob: 'src', owners: [{ kind: 'user', name: 'alice' }] },
+      { glob: 'src/**', owners: [{ kind: 'user', name: 'alice' }] },
+    ])
+  })
+
+  test('throws on invalid owner format', () => {
+    expect(() => parseCodeOwners('* invalid-owner')).toThrow('Invalid owner format.')
+  })
+})
+
+describe('getFileOwners', () => {
+  test('matches files to owners using last matching rule', () => {
+    const rules: CodeOwnersRule[] = [
+      { glob: '**', owners: [{ kind: 'user', name: 'alice' }] },
+      { glob: 'src/**', owners: [{ kind: 'user', name: 'bob' }] },
+    ]
+    const result = getFileOwners(['src/main.ts', 'README.md'], rules)
+    expect(result).toEqual([
+      { filename: 'src/main.ts', owners: [{ kind: 'user', name: 'bob' }] },
+      { filename: 'README.md', owners: [{ kind: 'user', name: 'alice' }] },
+    ])
+  })
+
+  test('returns empty owners when no rule matches', () => {
+    const rules: CodeOwnersRule[] = [{ glob: 'src/**', owners: [{ kind: 'user', name: 'alice' }] }]
+    const result = getFileOwners(['README.md'], rules)
+    expect(result).toEqual([{ filename: 'README.md', owners: [] }])
+  })
+})
+
+describe('listUniqueOwners', () => {
+  test('deduplicates owners by name', () => {
+    const alice = { kind: 'user' as const, name: 'alice' }
+    const bob = { kind: 'user' as const, name: 'bob' }
+    const result = listUniqueOwners([
+      { filename: 'a.ts', owners: [alice, bob] },
+      { filename: 'b.ts', owners: [alice] },
+    ])
+    expect(result).toEqual([alice, bob])
+  })
+
+  test('returns empty array when no owners', () => {
+    const result = listUniqueOwners([{ filename: 'a.ts', owners: [] }])
+    expect(result).toEqual([])
+  })
+})

--- a/codeowners-validator/jest.config.js
+++ b/codeowners-validator/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  transform: {
+    '^.+\\.tsx?$': '@swc/jest',
+  },
+  testEnvironment: 'node',
+}

--- a/codeowners-validator/package.json
+++ b/codeowners-validator/package.json
@@ -10,8 +10,8 @@
     "all": "pnpm type-check && pnpm package"
   },
   "dependencies": {
-    "@actions/core": "2.0.3",
-    "@actions/github": "6.0.1",
-    "minimatch": "10.1.1"
+    "@actions/core": "3.0.1",
+    "@actions/github": "9.1.1",
+    "minimatch": "10.2.3"
   }
 }

--- a/codeowners-validator/src/validate.ts
+++ b/codeowners-validator/src/validate.ts
@@ -1,6 +1,5 @@
 import * as core from '@actions/core'
 import { context, getOctokit } from '@actions/github'
-import { WebhookPayload } from '@actions/github/lib/interfaces'
 
 import { parseCodeOwners, getFileOwners, listUniqueOwners } from './parse'
 
@@ -14,7 +13,8 @@ const CommitContext = 'CODEOWNERS Validator'
 type MergeGroupPayload = {
   head_sha: string
 }
-type PullRequestPayload = WebhookPayload['pull_request'] & {
+type PullRequestPayload = {
+  number: number
   head: {
     sha: string
   }

--- a/deploybot/jest.config.js
+++ b/deploybot/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  transform: {
+    '^.+\\.tsx?$': '@swc/jest',
+  },
+  testEnvironment: 'node',
+}

--- a/deploybot/package.json
+++ b/deploybot/package.json
@@ -10,10 +10,10 @@
     "all": "pnpm type-check && pnpm package"
   },
   "dependencies": {
-    "@actions/core": "2.0.3",
-    "@actions/github": "6.0.1",
+    "@actions/core": "3.0.1",
+    "@actions/github": "9.1.1",
     "@slack/web-api": "7.18.0",
-    "js-yaml": "4.1.1"
+    "js-yaml": "4.2.0"
   },
   "devDependencies": {
     "@types/js-yaml": "4.0.9"

--- a/docker-image-tag/__mocks__/@actions/exec.js
+++ b/docker-image-tag/__mocks__/@actions/exec.js
@@ -1,1 +1,2 @@
-module.exports = { getExecOutput: () => Promise.resolve({ stdout: '', stderr: '', exitCode: 0 }) }
+const getExecOutput = jest.fn()
+module.exports = { getExecOutput }

--- a/docker-image-tag/__mocks__/@actions/exec.js
+++ b/docker-image-tag/__mocks__/@actions/exec.js
@@ -1,0 +1,1 @@
+module.exports = { getExecOutput: () => Promise.resolve({ stdout: '', stderr: '', exitCode: 0 }) }

--- a/docker-image-tag/__mocks__/@actions/github.js
+++ b/docker-image-tag/__mocks__/@actions/github.js
@@ -1,0 +1,1 @@
+module.exports = { context: { ref: '', sha: '' } }

--- a/docker-image-tag/__mocks__/@actions/github.js
+++ b/docker-image-tag/__mocks__/@actions/github.js
@@ -1,1 +1,2 @@
-module.exports = { context: { ref: '', sha: '' } }
+const context = { ref: '', sha: '' }
+module.exports = { context }

--- a/docker-image-tag/__tests__/tag.test.ts
+++ b/docker-image-tag/__tests__/tag.test.ts
@@ -1,35 +1,69 @@
-import { suffix } from '../src/tag'
+import { context } from '@actions/github'
+import { getExecOutput } from '@actions/exec'
 
-test('Generate valid suffix for docker image tag', () => {
-  const tests = [
-    {
-      type: 'hash',
-      ref: 'refs/heads/main',
-      sha: 'e78ab41287b43959657720615f80cc716f67226c',
-      want: 'e78ab41',
-    },
-    {
-      type: 'auto',
-      ref: 'refs/heads/main',
-      sha: 'e78ab41287b43959657720615f80cc716f67226c',
-      want: 'e78ab41',
-    },
-    {
-      type: 'tag',
-      ref: 'refs/tags/v1.0.0',
-      sha: 'e78ab41287b43959657720615f80cc716f67226c',
-      want: 'v1.0.0',
-    },
-    {
-      type: 'auto',
-      ref: 'refs/tags/v1.0.0',
-      sha: 'e78ab41287b43959657720615f80cc716f67226c',
-      want: 'v1.0.0',
-    },
-  ]
+import { suffix, generateTag } from '../src/tag'
 
-  tests.forEach(({ type, ref, sha, want }) => {
-    const got = suffix(type, ref, sha)
-    expect(got).toEqual(want)
+const mockGetExecOutput = getExecOutput as jest.Mock
+
+describe('suffix', () => {
+  test('hash type returns short commit hash', () => {
+    expect(suffix('hash', 'refs/heads/main', 'e78ab41287b43959657720615f80cc716f67226c')).toBe(
+      'e78ab41'
+    )
+  })
+
+  test('tag type returns tag value from ref', () => {
+    expect(suffix('tag', 'refs/tags/v1.0.0', 'e78ab41287b43959657720615f80cc716f67226c')).toBe(
+      'v1.0.0'
+    )
+  })
+
+  test('auto type returns tag when ref is a tag', () => {
+    expect(suffix('auto', 'refs/tags/v2.3.1', 'e78ab41287b43959657720615f80cc716f67226c')).toBe(
+      'v2.3.1'
+    )
+  })
+
+  test('auto type returns short hash when ref is a branch', () => {
+    expect(suffix('auto', 'refs/heads/main', 'e78ab41287b43959657720615f80cc716f67226c')).toBe(
+      'e78ab41'
+    )
+  })
+
+  test('throws on invalid type', () => {
+    expect(() => suffix('unknown', 'refs/heads/main', 'abc1234')).toThrow('invalid tag type')
+  })
+})
+
+describe('generateTag', () => {
+  beforeEach(() => {
+    context.ref = 'refs/heads/main'
+    context.sha = 'e78ab41287b43959657720615f80cc716f67226c'
+    mockGetExecOutput.mockResolvedValue({ stdout: '20260709-120000\n', stderr: '', exitCode: 0 })
+  })
+
+  test('generates tag with env prefix', async () => {
+    const result = await generateTag('production', 'hash')
+    expect(result).toEqual({
+      imageTag: 'production-20260709-120000-e78ab41',
+      latestTag: 'production-latest',
+    })
+  })
+
+  test('generates tag without env prefix', async () => {
+    const result = await generateTag('', 'hash')
+    expect(result).toEqual({
+      imageTag: '20260709-120000-e78ab41',
+      latestTag: 'latest',
+    })
+  })
+
+  test('generates tag with tag ref in auto mode', async () => {
+    context.ref = 'refs/tags/v1.0.0'
+    const result = await generateTag('staging', 'auto')
+    expect(result).toEqual({
+      imageTag: 'staging-20260709-120000-v1.0.0',
+      latestTag: 'staging-latest',
+    })
   })
 })

--- a/docker-image-tag/__tests__/tag.test.ts
+++ b/docker-image-tag/__tests__/tag.test.ts
@@ -43,10 +43,10 @@ describe('generateTag', () => {
   })
 
   test('generates tag with env prefix', async () => {
-    const result = await generateTag('production', 'hash')
+    const result = await generateTag('prod', 'hash')
     expect(result).toEqual({
-      imageTag: 'production-20260709-120000-e78ab41',
-      latestTag: 'production-latest',
+      imageTag: 'prod-20260709-120000-e78ab41',
+      latestTag: 'prod-latest',
     })
   })
 
@@ -60,10 +60,10 @@ describe('generateTag', () => {
 
   test('generates tag with tag ref in auto mode', async () => {
     context.ref = 'refs/tags/v1.0.0'
-    const result = await generateTag('staging', 'auto')
+    const result = await generateTag('stg', 'auto')
     expect(result).toEqual({
-      imageTag: 'staging-20260709-120000-v1.0.0',
-      latestTag: 'staging-latest',
+      imageTag: 'stg-20260709-120000-v1.0.0',
+      latestTag: 'stg-latest',
     })
   })
 })

--- a/docker-image-tag/jest.config.js
+++ b/docker-image-tag/jest.config.js
@@ -1,0 +1,11 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  transform: {
+    '^.+\\.tsx?$': '@swc/jest',
+  },
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@actions/github$': '<rootDir>/__mocks__/@actions/github.js',
+    '^@actions/exec$': '<rootDir>/__mocks__/@actions/exec.js',
+  },
+}

--- a/docker-image-tag/package.json
+++ b/docker-image-tag/package.json
@@ -10,8 +10,8 @@
     "all": "pnpm type-check && pnpm package"
   },
   "dependencies": {
-    "@actions/core": "2.0.3",
-    "@actions/exec": "2.0.0",
-    "@actions/github": "6.0.1"
+    "@actions/core": "3.0.1",
+    "@actions/exec": "3.0.0",
+    "@actions/github": "9.1.1"
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,10 @@
 /** @type {import('jest').Config} */
 module.exports = {
-  transform: {
-    '^.+\\.tsx?$': '@swc/jest',
-  },
-  testEnvironment: 'node',
+  projects: [
+    '<rootDir>/aws-ssm-parameters',
+    '<rootDir>/codeowners-validator',
+    '<rootDir>/deploybot',
+    '<rootDir>/docker-image-tag',
+  ],
   verbose: true,
 }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.34.4"
+  "packageManager": "pnpm@11.10.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,14 +45,14 @@ importers:
   aws-ssm-parameters:
     dependencies:
       '@actions/core':
-        specifier: 2.0.3
-        version: 2.0.3
+        specifier: 3.0.1
+        version: 3.0.1
       '@aws-sdk/client-ssm':
         specifier: 3.1078.0
         version: 3.1078.0
       js-yaml:
-        specifier: 4.1.1
-        version: 4.1.1
+        specifier: 4.2.0
+        version: 4.2.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -64,29 +64,29 @@ importers:
   codeowners-validator:
     dependencies:
       '@actions/core':
-        specifier: 2.0.3
-        version: 2.0.3
+        specifier: 3.0.1
+        version: 3.0.1
       '@actions/github':
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 9.1.1
+        version: 9.1.1
       minimatch:
-        specifier: 10.1.1
-        version: 10.1.1
+        specifier: 10.2.3
+        version: 10.2.3
 
   deploybot:
     dependencies:
       '@actions/core':
-        specifier: 2.0.3
-        version: 2.0.3
+        specifier: 3.0.1
+        version: 3.0.1
       '@actions/github':
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 9.1.1
+        version: 9.1.1
       '@slack/web-api':
         specifier: 7.18.0
         version: 7.18.0
       js-yaml:
-        specifier: 4.1.1
-        version: 4.1.1
+        specifier: 4.2.0
+        version: 4.2.0
     devDependencies:
       '@types/js-yaml':
         specifier: 4.0.9
@@ -95,34 +95,34 @@ importers:
   docker-image-tag:
     dependencies:
       '@actions/core':
-        specifier: 2.0.3
-        version: 2.0.3
+        specifier: 3.0.1
+        version: 3.0.1
       '@actions/exec':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: 3.0.0
+        version: 3.0.0
       '@actions/github':
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 9.1.1
+        version: 9.1.1
 
 packages:
 
-  '@actions/core@2.0.3':
-    resolution: {integrity: sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==}
+  '@actions/core@3.0.1':
+    resolution: {integrity: sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==}
 
-  '@actions/exec@2.0.0':
-    resolution: {integrity: sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==}
+  '@actions/exec@3.0.0':
+    resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
 
-  '@actions/github@6.0.1':
-    resolution: {integrity: sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==}
-
-  '@actions/http-client@2.2.3':
-    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+  '@actions/github@9.1.1':
+    resolution: {integrity: sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==}
 
   '@actions/http-client@3.0.2':
     resolution: {integrity: sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==}
 
-  '@actions/io@2.0.0':
-    resolution: {integrity: sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==}
+  '@actions/http-client@4.0.1':
+    resolution: {integrity: sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==}
+
+  '@actions/io@3.0.2':
+    resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
 
   '@aws-sdk/client-ssm@3.1078.0':
     resolution: {integrity: sha512-KthuEJv8S7SLpJDNQxNjHH5nv1rHE97tSDJY3vvh1hTN5fnTIbg/XGH71ChWfi/ZQDe5sT8jDBjQXKwOxYR6Sw==}
@@ -518,18 +518,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
-
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -667,53 +655,47 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@octokit/auth-token@4.0.0':
-    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
-    engines: {node: '>= 18'}
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
 
-  '@octokit/core@5.2.2':
-    resolution: {integrity: sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==}
-    engines: {node: '>= 18'}
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
 
-  '@octokit/endpoint@9.0.6':
-    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
-    engines: {node: '>= 18'}
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
 
-  '@octokit/graphql@7.1.1':
-    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
-    engines: {node: '>= 18'}
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
 
-  '@octokit/openapi-types@20.0.0':
-    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
 
-  '@octokit/openapi-types@24.2.0':
-    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
-
-  '@octokit/plugin-paginate-rest@9.2.2':
-    resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
-    engines: {node: '>= 18'}
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
     peerDependencies:
-      '@octokit/core': '5'
+      '@octokit/core': '>=6'
 
-  '@octokit/plugin-rest-endpoint-methods@10.4.1':
-    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
-    engines: {node: '>= 18'}
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
     peerDependencies:
-      '@octokit/core': '5'
+      '@octokit/core': '>=6'
 
-  '@octokit/request-error@5.1.1':
-    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
-    engines: {node: '>= 18'}
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
 
-  '@octokit/request@8.4.1':
-    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
-    engines: {node: '>= 18'}
+  '@octokit/request@10.0.11':
+    resolution: {integrity: sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==}
+    engines: {node: '>= 20'}
 
-  '@octokit/types@12.6.0':
-    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
-
-  '@octokit/types@13.10.0':
-    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
   '@oxfmt/binding-android-arm-eabi@0.57.0':
     resolution: {integrity: sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig==}
@@ -1461,12 +1443,16 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.9.11:
     resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
     hasBin: true
 
-  before-after-hook@2.2.3:
-    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
   bowser@2.13.1:
     resolution: {integrity: sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==}
@@ -1476,6 +1462,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1551,6 +1541,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1582,9 +1576,6 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-
-  deprecation@2.3.1:
-    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -2001,8 +1992,8 @@ packages:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2012,6 +2003,9 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -2068,9 +2062,9 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  minimatch@10.1.1:
-    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2376,16 +2370,12 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@6.27.0:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  universal-user-agent@6.0.1:
-    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2447,36 +2437,36 @@ packages:
 
 snapshots:
 
-  '@actions/core@2.0.3':
+  '@actions/core@3.0.1':
     dependencies:
-      '@actions/exec': 2.0.0
+      '@actions/exec': 3.0.0
+      '@actions/http-client': 4.0.1
+
+  '@actions/exec@3.0.0':
+    dependencies:
+      '@actions/io': 3.0.2
+
+  '@actions/github@9.1.1':
+    dependencies:
       '@actions/http-client': 3.0.2
-
-  '@actions/exec@2.0.0':
-    dependencies:
-      '@actions/io': 2.0.0
-
-  '@actions/github@6.0.1':
-    dependencies:
-      '@actions/http-client': 2.2.3
-      '@octokit/core': 5.2.2
-      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.2)
-      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
-      '@octokit/request': 8.4.1
-      '@octokit/request-error': 5.1.1
-      undici: 5.29.0
-
-  '@actions/http-client@2.2.3':
-    dependencies:
-      tunnel: 0.0.6
-      undici: 5.29.0
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+      '@octokit/request': 10.0.11
+      '@octokit/request-error': 7.1.0
+      undici: 6.27.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
       undici: 6.27.0
 
-  '@actions/io@2.0.0': {}
+  '@actions/http-client@4.0.1':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.27.0
+
+  '@actions/io@3.0.2': {}
 
   '@aws-sdk/client-ssm@3.1078.0':
     dependencies:
@@ -2906,14 +2896,6 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@fastify/busboy@2.1.1': {}
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
-
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -3166,63 +3148,57 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@octokit/auth-token@4.0.0': {}
+  '@octokit/auth-token@6.0.0': {}
 
-  '@octokit/core@5.2.2':
+  '@octokit/core@7.0.6':
     dependencies:
-      '@octokit/auth-token': 4.0.0
-      '@octokit/graphql': 7.1.1
-      '@octokit/request': 8.4.1
-      '@octokit/request-error': 5.1.1
-      '@octokit/types': 13.10.0
-      before-after-hook: 2.2.3
-      universal-user-agent: 6.0.1
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.11
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
 
-  '@octokit/endpoint@9.0.6':
+  '@octokit/endpoint@11.0.3':
     dependencies:
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
 
-  '@octokit/graphql@7.1.1':
+  '@octokit/graphql@9.0.3':
     dependencies:
-      '@octokit/request': 8.4.1
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
+      '@octokit/request': 10.0.11
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
 
-  '@octokit/openapi-types@20.0.0': {}
+  '@octokit/openapi-types@27.0.0': {}
 
-  '@octokit/openapi-types@24.2.0': {}
-
-  '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.2)':
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
     dependencies:
-      '@octokit/core': 5.2.2
-      '@octokit/types': 12.6.0
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
 
-  '@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.2)':
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
     dependencies:
-      '@octokit/core': 5.2.2
-      '@octokit/types': 12.6.0
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
 
-  '@octokit/request-error@5.1.1':
+  '@octokit/request-error@7.1.0':
     dependencies:
-      '@octokit/types': 13.10.0
-      deprecation: 2.3.1
-      once: 1.4.0
+      '@octokit/types': 16.0.0
 
-  '@octokit/request@8.4.1':
+  '@octokit/request@10.0.11':
     dependencies:
-      '@octokit/endpoint': 9.0.6
-      '@octokit/request-error': 5.1.1
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
 
-  '@octokit/types@12.6.0':
+  '@octokit/types@16.0.0':
     dependencies:
-      '@octokit/openapi-types': 20.0.0
-
-  '@octokit/types@13.10.0':
-    dependencies:
-      '@octokit/openapi-types': 24.2.0
+      '@octokit/openapi-types': 27.0.0
 
   '@oxfmt/binding-android-arm-eabi@0.57.0':
     optional: true
@@ -3758,9 +3734,11 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.9.11: {}
 
-  before-after-hook@2.2.3: {}
+  before-after-hook@4.0.0: {}
 
   bowser@2.13.1: {}
 
@@ -3772,6 +3750,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -3837,6 +3819,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -3854,8 +3838,6 @@ snapshots:
   deepmerge@4.3.1: {}
 
   delayed-stream@1.0.0: {}
-
-  deprecation@2.3.1: {}
 
   detect-newline@3.1.0: {}
 
@@ -4499,13 +4481,15 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
   jsesc@3.1.0: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-with-bigint@3.5.8: {}
 
   json5@2.2.3: {}
 
@@ -4550,9 +4534,9 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  minimatch@10.1.1:
+  minimatch@10.2.3:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      brace-expansion: 5.0.7
 
   minimatch@3.1.2:
     dependencies:
@@ -4846,13 +4830,9 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
-
   undici@6.27.0: {}
 
-  universal-user-agent@6.0.1: {}
+  universal-user-agent@7.0.3: {}
 
   unrs-resolver@1.11.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+engineStrict: true
 minimumReleaseAge: 10080 # 1 week
 minimumReleaseAgeExclude:
   - typescript
@@ -11,4 +12,6 @@ savePrefix: ''
 # preinstall/install/postinstall スクリプトの実行を許可するかどうか
 # デフォルトは false
 allowBuilds:
+  '@swc/core': true
   esbuild: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary / 概要

Renovate PR 6件分の依存更新を一括適用し、pnpm v11 移行と jest の projects 構成化、codeowners-validator のテスト追加を行う。

お手すきでレビューお願いします 🙏

## Changes / 変更内容

- @actions/core 2.0→3.0, @actions/github 6.0→9.1, @actions/exec 2.0→3.0（ESM-only 対応含む）
- js-yaml 4.1.1→4.2.0, minimatch 10.1.1→10.2.3（security fix）
- pnpm 10→11（.npmrc は npm 互換で残置、engineStrict を pnpm-workspace.yaml にも追加）
- @actions/github v9 で削除された deep import を修正（codeowners-validator/src/validate.ts）
- jest を projects 構成に変更（ESM-only 依存のワークスペース解決に対応）
- codeowners-validator のテスト 17件を追加

対応する Renovate PR: #107, #106, #108, #116, #110, #113

## Type of Change / 変更タイプ

- [x] Bug fix / バグ修正（security fix）
- [x] New feature / 新機能（テスト追加）