### PR TITLE
chore: disable e2e deployment tracking and add explicit minimumReleaseAge

### DIFF
--- a/.github/workflows/deploybot.yaml
+++ b/.github/workflows/deploybot.yaml
@@ -9,7 +9,9 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    environment: e2e
+    environment:
+      name: e2e
+      deployment: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>globis-org/renovate-config:sre"],
+  "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "rangeStrategy": "pin",


### PR DESCRIPTION
## Summary

- e2e environment に `deployment: false` を設定し、Deployments タブへの記録を停止。required reviewers と secret 保護は維持される
- `renovate.json` に `minimumReleaseAge: "7 days"` を明示追加。extends 先の shared preset に設定済みだが、supply-chain-audit は自ファイルでの明示指定を要求する

## Test plan

- [x] CI パス
- [x] e2e ジョブが approval 後に正常実行される（deployment: false でも protection rules は維持）
- [ ] 次回の supply-chain-audit で `missing-bot-cooldown` 違反が解消される

対応 Issue: https://github.com/globis-org/sre-actions/issues/136 （gdp-security の supply-chain-audit により自動 close されます。手動 close はしません）
親 Issue: https://github.com/globis-org/core-infra/issues/4419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
